### PR TITLE
Updated README with necessary changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,46 @@
 # Engineering-blog-samples
 
-## About Respository ##
+## About Repository
 
 Engineers at LoginRadius are not limited to develop, test, deploy, and maintain the **LoginRadius Identity Platform**. They are highly motivated to build and learn something new every day. As a part of our Giving Back To Community initiative, we aim to share the same with the developers worldwide via our [Engineering Blogs](https://www.loginradius.com/engineering/blog).
 
 This repository contains the sample code used in the engineering blogs written for the initiative mentioned above.
 
 
-
-## About LoginRadius ##
+## About LoginRadius 
 
 LoginRadius empowers businesses to deliver a delightful customer experience and win customer trust.  Using the LoginRadius Identity Platform, you can offer a streamlined registration and login processes while protecting customer accounts and complying with data privacy regulations.
 
-## How to use ##
+## How to use 
 
-The root folder contains langauge specific folder for code samples. You can browse to partciular directory and access the code sample as per your need
+First, clone this repository to your desired location in the PC using the following command : 
 
-e.g.
-
-```
-cd Deno/
-
+``` git clone https://github.com/LoginRadius/engineering-blog-samples.git
 ```
 
-In Deno folder you can find a number of project samples.
-If you want to check with sample how to create Rest API in Deno, please move to theat directory. 
+
+The root folder contains the language specific folder for code samples. You can browse to particular directory and access the code sample as per your need
+
+For e.g.
 
 ```
-cd  RestAPIWithDeno/
+cd Deno
+ls
+
+```
+This command in the terminal would open the Deno folder and list all the subfolders. This is where you can find a number of project samples.   
+
+Now, if you want to check with sample how to create Rest API in Deno, please move to that directory :
+
+```
+cd  RestAPIWithDeno
 
 ```
 
-Here you can find the instructsion to run that sample project
+Here you can find the instructions to run that sample project in Deno.
 
+## License 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)   
+Login Radius is under the [MIT License](/LICENSE)
 
 


### PR DESCRIPTION
1. Fixed all the Typos.
2. Added Licensing link and the MIT License badge like other official repositories
3. The How to Use section was unclear regarding instructions with few grammatical errors and irrelevant forward slashes in directory traversal. Fixed it.
4. Formatted the Readme removing irrelevant trailing hashtags
Closes #23